### PR TITLE
Run all shell script commands with exec

### DIFF
--- a/scripts/create-validators.sh
+++ b/scripts/create-validators.sh
@@ -7,7 +7,7 @@
 if [ "$START_VALIDATOR" != "" ]; then
 	if [ ! -d ~/.lighthouse/validators ]; then
 		if [ "$SEND_DEPOSITS" != "" ]; then
-			lighthouse \
+			exec lighthouse \
 				--debug-level $DEBUG_LEVEL \
 				account \
 				validator \
@@ -19,7 +19,7 @@ if [ "$START_VALIDATOR" != "" ]; then
 				random \
 				$VALIDATOR_COUNT
 		else
-			lighthouse \
+			exec lighthouse \
 				--debug-level $DEBUG_LEVEL \
 				account \
 				validator \

--- a/scripts/start-beacon-node.sh
+++ b/scripts/start-beacon-node.sh
@@ -6,7 +6,7 @@ if [ "$START_VALIDATOR" != "" ]; then
 	ETH1_FLAG=--eth1
 fi
 
-lighthouse \
+exec lighthouse \
 	--debug-level $DEBUG_LEVEL \
 	beacon_node \
 	--eth1-endpoint $VOTING_ETH1_NODE \

--- a/scripts/start-geth.sh
+++ b/scripts/start-geth.sh
@@ -3,5 +3,5 @@
 # Starts a local fast-synced geth node.
 
 if [ "$START_GETH" != "" ]; then
-	geth --goerli --rpc --rpcaddr "0.0.0.0" --rpcvhosts=*
+	exec geth --goerli --rpc --rpcaddr "0.0.0.0" --rpcvhosts=*
 fi

--- a/scripts/start-validator-client.sh
+++ b/scripts/start-validator-client.sh
@@ -11,7 +11,7 @@ if [ "$START_VALIDATOR" != "" ]; then
 		sleep 1
 	done
 
-	lighthouse \
+	exec lighthouse \
 		--debug-level $DEBUG_LEVEL \
 		validator \
 		--server http://beacon_node:5052


### PR DESCRIPTION
Fixes https://github.com/sigp/lighthouse/issues/839.

Running the commands in the shell script without `exec` leads to SIGTERM signals not reaching the application. (Source https://hynek.me/articles/docker-signals/ point 2)