### PR TITLE
scripts/start-validator-client.sh failed as new slashing_protection.sqlite file

### DIFF
--- a/scripts/start-validator-client.sh
+++ b/scripts/start-validator-client.sh
@@ -5,7 +5,7 @@
 # validator client.
 
 if [ "$START_VALIDATOR" != "" ]; then
-	while [ $(ls -1 ~/.lighthouse/validators | wc -l) != $VALIDATOR_COUNT ]
+	while [ $(ls -1 -d ~/.lighthouse/validators | wc -l) != $VALIDATOR_COUNT ]
 	do
 		echo "Waiting for $VALIDATOR_COUNT validators."
 		sleep 1


### PR DESCRIPTION
As now there’s also file slashing_protection.sqlite which would make the $VALIDATOR_COUNT condition check fail. Fixing this by add ‘-d’ to list directory only