### PR TITLE
Configure graffiti through $GRAFFITI

### DIFF
--- a/default.env
+++ b/default.env
@@ -7,6 +7,9 @@ DEBUG_LEVEL=info
 # public testnet) set this value. Allowed values are: altona or medalla
 TESTNET=
 
+# Adds an arbitary string to the proposing block
+GRAFFITI=
+
 # Set to anything other than empty to start the validator client.
 START_VALIDATOR=
 

--- a/default.env
+++ b/default.env
@@ -7,7 +7,7 @@ DEBUG_LEVEL=info
 # public testnet) set this value. Allowed values are: altona or medalla
 TESTNET=
 
-# Adds an arbitary string to the proposing block
+# Add an arbitary string to the proposing block
 GRAFFITI=
 
 # Set to anything other than empty to start the validator client.

--- a/scripts/start-beacon-node.sh
+++ b/scripts/start-beacon-node.sh
@@ -10,6 +10,10 @@ if [ "$TESTNET" != "" ]; then
 	TESTNET_PARAM="--testnet $TESTNET"
 fi
 
+if [ "$GRAFFITI" != "" ]; then
+	GRAFFITI_PARAM="--graffiti $GRAFFITI"
+fi
+
 exec lighthouse \
 	--debug-level $DEBUG_LEVEL \
 	$TESTNET_PARAM \
@@ -20,4 +24,5 @@ exec lighthouse \
 	--http-address 0.0.0.0 \
 	--ws \
 	--ws-address 0.0.0.0 \
+	$GRAFFITI_PARAM \
 	$ETH1_FLAG


### PR DESCRIPTION
Make the graffiti flag configurable through an environment variable so the user doesn't need to make code changes to the startup script.

This is useful e.g. to earn the POAP badge for medalla testnet launch: https://medalla.beaconcha.in/poap