### PR TITLE
Rename lightouse data to ~./.lighthouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ The following features are available:
 
 `$ docker-compose up`
 
-A `.lighthouse` directory will be created in the repository root which contains
-the validator keys, beacon node database and other Lighthouse files.
+A `.lighthouse` directory will be created in your home directory. It will contain the validator keys, beacon node database and other Lighthouse files.
 
 ## Configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     beacon_node:
         image: sigp/lighthouse:latest
         volumes:
-            - ./lighthouse-data:/root/.lighthouse
+            - ~/.lighthouse:/root/.lighthouse
             - ./scripts:/root/scripts
             - ./network:/root/network
         ports:
@@ -17,7 +17,7 @@ services:
     validator_client:
         image: sigp/lighthouse:latest
         volumes:
-            - ./lighthouse-data:/root/.lighthouse
+            - ~/.lighthouse:/root/.lighthouse
             - ./scripts:/root/scripts
         depends_on:
             - beacon_node


### PR DESCRIPTION
Original issue is on lighthouse repo: https://github.com/sigp/lighthouse/issues/1443

As @AgeManning suggested, this PR renames `lighthouse-data` to `~/.lighthouse` (and updates the doc along with it).

Before merging in, I would simply point out the fact that I don't know how this will behave on Windows...
I had the idea of using $HOME (which is a mandatory env var for POSIX), but the problem for Windows would stay.

