### PR TITLE
Update deprecated HTTP-RPC flags

### DIFF
--- a/scripts/start-geth.sh
+++ b/scripts/start-geth.sh
@@ -3,5 +3,5 @@
 # Starts a local fast-synced geth node.
 
 if [ "$START_GETH" != "" ]; then
-	exec geth --goerli --rpc --rpcaddr "0.0.0.0" --rpcvhosts=*
+	exec geth --goerli --http --http.addr "0.0.0.0" --http.vhosts=*
 fi


### PR DESCRIPTION
At startup geth prints
```
WARN [08-06|19:23:26.749] The flag --rpc is deprecated and will be removed in the future, please use --http 
WARN [08-06|19:23:26.749] The flag --rpcaddr is deprecated and will be removed in the future, please use --http.addr 
WARN [08-06|19:23:26.749] The flag --rpcvhosts is deprecated and will be removed in the future, please use --http.vhosts
```

This PR updates the deprecated flags.