### PR TITLE
added --max-skip-slots to beacon node start script

### DIFF
--- a/scripts/start-beacon-node.sh
+++ b/scripts/start-beacon-node.sh
@@ -24,5 +24,6 @@ exec lighthouse \
 	--http-address 0.0.0.0 \
 	--ws \
 	--ws-address 0.0.0.0 \
+	--max-skip-slots 700 \
 	$GRAFFITI_PARAM \
 	$ETH1_FLAG


### PR DESCRIPTION
Needed as per https://github.com/sigp/lighthouse/releases/tag/v0.2.4