### PR TITLE
Adopted all path to user lighthouse instead of root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 network/
 secrets/
-.lighthouse/
+lighthouse-data/
 .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     beacon_node:
         image: sigp/lighthouse:latest
         volumes:
-            - ./lighthouse-data:/root/.lighthouse
-            - ./scripts:/root/scripts
+            - ./lighthouse-data:/home/lighthouse/.lighthouse
+            - ./scripts:/home/lighthouse/scripts
             - ./network:/root/network
         ports:
             - 5052:5052/tcp
@@ -13,27 +13,27 @@ services:
             - 9000:9000/tcp
             - 9000:9000/udp
         env_file: .env
-        command: sh /root/scripts/start-beacon-node.sh
+        command: sh /home/lighthouse/scripts/start-beacon-node.sh
     validator_client:
         image: sigp/lighthouse:latest
         volumes:
-            - ./lighthouse-data:/root/.lighthouse
-            - ./scripts:/root/scripts
+            - ./lighthouse-data:/home/lighthouse/.lighthouse
+            - ./scripts:/home/lighthouse/scripts
         depends_on:
             - beacon_node
         env_file: .env
-        command: sh /root/scripts/start-validator-client.sh
+        command: sh /home/lighthouse/scripts/start-validator-client.sh
     geth:
         build:
             context: geth
         volumes:
             - geth:/root/.ethereum
-            - ./scripts:/root/scripts
+            - ./scripts:/home/lighthouse/scripts
         ports:
             - 30303:30303/tcp
             - 30303:30303/udp
         env_file: .env
-        command: sh /root/scripts/start-geth.sh
+        command: sh /home/lighthouse/scripts/start-geth.sh
 
 volumes:
     geth:


### PR DESCRIPTION
Fixes #17 

Some pitfalls which may need to be addressed with a good documentation or a `entrypoint.sh`

- The already existing data needs to be `chown` to the new `lighthouse` user (uid: 999)
- The `validator_definitions.yml` needs to be edited to use the new paths