### PR TITLE
have geth data files on the same place as lighthouse data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 network/
 secrets/
+geth-data/
 lighthouse-data/
 .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,5 +35,3 @@ services:
         env_file: .env
         command: /root/scripts/start-geth.sh
 
-volumes:
-    geth:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
         build:
             context: geth
         volumes:
-            - geth:/root/.ethereum
+            - ./geth-data:/root/.ethereum
             - ./scripts:/root/scripts
         ports:
             - 30303:30303/tcp


### PR DESCRIPTION
It would be nice to have `geth` data files also next to `docker-compose` configuration the same way we have there `lighthouse` data.

It is nice when in need of wiping or inspecting the data, so we don't need to dig deep somewhere in `/var/lib/docker/volumes/lighthousedocker_geth/_data/`.