### PR TITLE
Support multiple datadirs for multiple networks

### DIFF
--- a/default.env
+++ b/default.env
@@ -3,8 +3,11 @@
 # Set to `debug` or `trace` for detailed information.
 DEBUG_LEVEL=info
 
+# Specify the default testnet for setting the right directories.
+DEFAULT_TESTNET=medalla
+
 # To specify a specific testnet (Lighthouse defaults to the latest running
-# public testnet) set this value. Allowed values are: altona or medalla
+# public testnet) set this value. Allowed values are: altona, medalla and spadina
 TESTNET=
 
 # Add an arbitary string to the proposing block

--- a/default.env
+++ b/default.env
@@ -3,9 +3,6 @@
 # Set to `debug` or `trace` for detailed information.
 DEBUG_LEVEL=info
 
-# Specify the default testnet for setting the right directories.
-DEFAULT_TESTNET=medalla
-
 # To specify a specific testnet (Lighthouse defaults to the latest running
 # public testnet) set this value. Allowed values are: altona, medalla and spadina
 TESTNET=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
         volumes:
             - ./lighthouse-data:/root/.lighthouse
             - ./scripts:/root/scripts
-            - ./network:/root/network
         ports:
             - 5052:5052/tcp
             - 5053:5053/tcp

--- a/scripts/start-beacon-node.sh
+++ b/scripts/start-beacon-node.sh
@@ -6,9 +6,13 @@ if [ "$START_VALIDATOR" != "" ]; then
 	ETH1_FLAG=--eth1
 fi
 
-if [ "$TESTNET" != "" ]; then
-	TESTNET_PARAM="--testnet $TESTNET"
+
+if [ "$TESTNET" = "" ]; then
+	TESTNET=$DEFAULT_TESTNET
 fi
+
+
+DATADIR=/root/.lighthouse/$TESTNET
 
 if [ "$GRAFFITI" != "" ]; then
 	GRAFFITI_PARAM="--graffiti $GRAFFITI"
@@ -16,7 +20,8 @@ fi
 
 exec lighthouse \
 	--debug-level $DEBUG_LEVEL \
-	$TESTNET_PARAM \
+	--testnet $TESTNET \
+	--datadir $DATADIR \
 	beacon_node \
 	--eth1-endpoint $VOTING_ETH1_NODE \
 	--network-dir /root/network \

--- a/scripts/start-beacon-node.sh
+++ b/scripts/start-beacon-node.sh
@@ -2,6 +2,8 @@
 #
 # Starts a beacon node.
 
+DEFAULT_TESTNET=medalla
+
 if [ "$START_VALIDATOR" != "" ]; then
 	ETH1_FLAG=--eth1
 fi

--- a/scripts/start-beacon-node.sh
+++ b/scripts/start-beacon-node.sh
@@ -24,7 +24,6 @@ exec lighthouse \
 	--datadir $DATADIR \
 	beacon_node \
 	--eth1-endpoint $VOTING_ETH1_NODE \
-	--network-dir /root/network \
 	--http \
 	--http-address 0.0.0.0 \
 	--ws \

--- a/scripts/start-validator-client.sh
+++ b/scripts/start-validator-client.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+DEFAULT_TESTNET=medalla
+
 # Set testnet name
 if [ "$TESTNET" = "" ]; then
 	TESTNET=$DEFAULT_TESTNET

--- a/scripts/start-validator-client.sh
+++ b/scripts/start-validator-client.sh
@@ -1,23 +1,29 @@
 #! /bin/bash
 
-WALLET_NAME=validators
-WALLET_PASSFILE=~/.lighthouse/secrets/$WALLET_NAME.pass
-
-if [ "$TESTNET" != "" ]; then
-	TESTNET_PARAM="--testnet $TESTNET"
+# Set testnet name
+if [ "$TESTNET" = "" ]; then
+	TESTNET=$DEFAULT_TESTNET
 fi
 
+# Base dir
+DATADIR=/root/.lighthouse/$TESTNET
+
+WALLET_NAME=validators
+WALLET_PASSFILE=$DATADIR/secrets/$WALLET_NAME.pass
+
+
 if [ "$START_VALIDATOR" != "" ]; then
-	if [ ! -d ~/.lighthouse/secrets ]; then
-		cd ~/.lighthouse; mkdir secrets
+	if [ ! -d $DATADIR/secrets ]; then
+		cd $DATADIR; mkdir secrets
 	fi
 
-	if [ ! -d ~/.lighthouse/wallets ]; then
+	if [ ! -d $DATADIR/wallets ]; then
 		lighthouse \
 			--debug-level $DEBUG_LEVEL \
-			$TESTNET_PARAM \
+			--testnet $TESTNET \
 			account \
 			wallet \
+			--base-dir $DATADIR/wallets \
 			create \
 			--name $WALLET_NAME \
 			--password-file $WALLET_PASSFILE
@@ -27,18 +33,23 @@ if [ "$START_VALIDATOR" != "" ]; then
 
 	lighthouse \
 		--debug-level $DEBUG_LEVEL \
-		$TESTNET_PARAM \
+		--testnet $TESTNET \
 		account \
 		validator \
+		--base-dir $DATADIR/wallets \
 		create \
 		--wallet-name $WALLET_NAME \
 		--wallet-password $WALLET_PASSFILE \
+		--validator-dir $DATADIR/validators \
+		--secrets-dir $DATADIR/secrets \
 		--at-most $VALIDATOR_COUNT &&
 
 	exec lighthouse \
 		--debug-level $DEBUG_LEVEL \
-		$TESTNET_PARAM \
+		--testnet $TESTNET \
+		--datadir $DATADIR/validators \
 		validator \
+		--secrets-dir $DATADIR/secrets \
 		--auto-register \
 		--server http://beacon_node:5052
 fi


### PR DESCRIPTION
Currently, even though we support multiple networks in docker, we don't have good support for multiple datadirs for these networks.

The current directory structure is a mess and it's pretty hard to specify the right flags in a docker setup.
This will be easier once https://github.com/sigp/lighthouse/pull/1532 gets merged. 

However, since spadina launch is tomorrow, this PR aims to be sort of a temporary fix to support multiple networks using existing directory flags.

The directory structure will be similar to the above linked PR (top level `~/.lighthouse` and a directory for every named testnet).

For the user who was running medalla and wants to run spadina now, the steps would be
1. Create a new `medalla` folder in `lighthouse-data` and move all folders inside the new `medalla` directory.
2. Change the `TESTNET` value in `.env` to spadina
3. `docker-compose up`