### PR TITLE
Support importing launchpad validators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ network/
 secrets/
 geth-data/
 lighthouse-data/
+validator_keys/
 .env

--- a/default.env
+++ b/default.env
@@ -18,7 +18,17 @@ START_VALIDATOR=
 # The following settings are only required if `START_VALIDATOR` is enabled and
 # `VALIDATOR_COUNT` is greater than zero.
 
-# The number of validators that should be created on first boot.
+# Set to anything other than empty to import keystore files generated with
+# eth2.0-deposit-cli
+IMPORT_LAUNCHPAD_KEYSTORES=
+
+# Set to the keystore encryption password used in eth2.0-deposit-cli. Only
+# required if `IMPORT_LAUNCHPAD_KEYSTORES` is set.
+LAUNCHPAD_KEYSTORE_PASSWD=
+
+# If `IMPORT_LAUNCHPAD_KEYSTORES` is not set, a new wallet will be generated
+# and validators derived from it. `VALIDATOR_COUNT` is the number of validators
+# that should be created on first boot.
 VALIDATOR_COUNT=1
 
 # Set to anything other than empty to start a geth instance.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
         volumes:
             - ./lighthouse-data:/root/.lighthouse
             - ./scripts:/root/scripts
+            - ./validator_keys:/root/validator_keys
         depends_on:
             - beacon_node
         env_file: .env
@@ -33,4 +34,3 @@ services:
             - 30303:30303/udp
         env_file: .env
         command: /root/scripts/start-geth.sh
-

--- a/scripts/start-validator-client.sh
+++ b/scripts/start-validator-client.sh
@@ -15,32 +15,41 @@ WALLET_PASSFILE=$DATADIR/secrets/$WALLET_NAME.pass
 
 
 if [ "$START_VALIDATOR" != "" ]; then
-	if [ ! -d $DATADIR/secrets ]; then
-		cd $DATADIR; mkdir secrets
-	fi
+	if [ "$IMPORT_LAUNCHPAD_KEYSTORES" != "" ]; then
+		echo $LAUNCHPAD_KEYSTORE_PASSWD | lighthouse \
+			--testnet $TESTNET \
+			account validator import \
+			--directory /root/validator_keys \
+			--reuse-password \
+			--stdin-inputs
+	else
+		if [ ! -d $DATADIR/secrets ]; then
+			cd $DATADIR; mkdir secrets
+		fi
 
-	if [ ! -d $DATADIR/wallets ]; then
+		if [ ! -d $DATADIR/wallets ]; then
+			lighthouse \
+				--debug-level $DEBUG_LEVEL \
+				--testnet $TESTNET \
+				account \
+				wallet \
+				create \
+				--name $WALLET_NAME \
+				--password-file $WALLET_PASSFILE
+		else
+			echo "Wallet directory already exists. Will not create wallet."
+		fi
+
 		lighthouse \
 			--debug-level $DEBUG_LEVEL \
 			--testnet $TESTNET \
 			account \
-			wallet \
+			validator \
 			create \
-			--name $WALLET_NAME \
-			--password-file $WALLET_PASSFILE
-	else
-		echo "Wallet directory already exists. Will not create wallet."
+			--wallet-name $WALLET_NAME \
+			--wallet-password $WALLET_PASSFILE \
+			--at-most $VALIDATOR_COUNT
 	fi
-
-	lighthouse \
-		--debug-level $DEBUG_LEVEL \
-		--testnet $TESTNET \
-		account \
-		validator \
-		create \
-		--wallet-name $WALLET_NAME \
-		--wallet-password $WALLET_PASSFILE \
-		--at-most $VALIDATOR_COUNT &&
 
 	exec lighthouse \
 		--debug-level $DEBUG_LEVEL \


### PR DESCRIPTION
This PR makes it possible to move `validator_keys` folder created with `eth2.0-deposit-cli` to `lighthouse-docker` project root and have `lighthouse-docker` import the keystores.

The current way of creating a wallet and deriving validators exposes the seed (and withdrawal key) to the (most likely internet connected) docker host. Importing `eth2.0-deposit-cli` keystores is important since it lets me keep the seed and withdrawal key offline.