### PR TITLE
Use env to enable beacon node metrics endpoint

### DIFF
--- a/default.env
+++ b/default.env
@@ -40,3 +40,6 @@ START_GETH=
 # This is the node that beacon nodes should use whilst they are running and
 # producing blocks. Does not require any accounts.
 VOTING_ETH1_NODE=http://geth:8545
+
+# Set to anything other than empty to enable the metrics endpoint port 5054 on beacon node.
+ENABLE_METRICS=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
         ports:
             - 5052:5052/tcp
             - 5053:5053/tcp
+            - 5054:5054/tcp     # metrics endpoint
             - 9000:9000/tcp
             - 9000:9000/udp
         env_file: .env

--- a/scripts/start-beacon-node.sh
+++ b/scripts/start-beacon-node.sh
@@ -13,6 +13,9 @@ if [ "$TESTNET" = "" ]; then
 	TESTNET=$DEFAULT_TESTNET
 fi
 
+if [ "$ENABLE_METRICS" != "" ]; then
+	METRICS_PARAMS="--metrics --metrics-address 0.0.0.0 "
+fi
 
 if [ "$GRAFFITI" != "" ]; then
 	GRAFFITI_PARAM="--graffiti $GRAFFITI"
@@ -25,6 +28,7 @@ exec lighthouse \
 	--eth1-endpoint $VOTING_ETH1_NODE \
 	--http \
 	--http-address 0.0.0.0 \
+	$METRICS_PARAMS \
 	--ws \
 	--ws-address 0.0.0.0 \
 	--max-skip-slots 700 \


### PR DESCRIPTION
A few minor changes to enable beacon node's metrics endpoint using ENABLE_METRICS env var.