### PR TITLE
Configurable lighthouse and geth docker tags

### DIFF
--- a/default.env
+++ b/default.env
@@ -1,3 +1,8 @@
+# Docker tags to pull. Can be used to control which Lighthouse and Geth
+# versions are deployed.
+LIGHTHOUSE_VERSION=v0.3.3
+GETH_VERSION=release-1.9
+
 # The logging level.
 #
 # Set to `debug` or `trace` for detailed information.

--- a/default.env
+++ b/default.env
@@ -1,6 +1,6 @@
 # Docker tags to pull. Can be used to control which Lighthouse and Geth
 # versions are deployed.
-LIGHTHOUSE_VERSION=v0.3.3
+LIGHTHOUSE_VERSION=v0.3.5
 GETH_VERSION=release-1.9
 
 # The logging level.

--- a/default.env
+++ b/default.env
@@ -1,6 +1,6 @@
 # Docker tags to pull. Can be used to control which Lighthouse and Geth
 # versions are deployed.
-LIGHTHOUSE_VERSION=v0.3.5
+LIGHTHOUSE_VERSION=v1.0.1
 GETH_VERSION=release-1.9
 
 # The logging level.

--- a/default.env
+++ b/default.env
@@ -2,9 +2,9 @@
 # versions are deployed.
 #
 # Search for a valid Docker tag on https://hub.docker.com/r/sigp/lighthouse/tags
-LIGHTHOUSE_VERSION=
+LIGHTHOUSE_VERSION=latest
 # Search for a valid Docker tag on https://hub.docker.com/r/ethereum/client-go/tags
-GETH_VERSION=
+GETH_VERSION=stable
 
 # The logging level.
 #

--- a/default.env
+++ b/default.env
@@ -1,7 +1,10 @@
 # Docker tags to pull. Can be used to control which Lighthouse and Geth
 # versions are deployed.
-LIGHTHOUSE_VERSION=v1.0.1
-GETH_VERSION=release-1.9
+#
+# Search for a valid Docker tag on https://hub.docker.com/r/sigp/lighthouse/tags
+LIGHTHOUSE_VERSION=
+# Search for a valid Docker tag on https://hub.docker.com/r/ethereum/client-go/tags
+GETH_VERSION=
 
 # The logging level.
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.0"
 
 services:
     beacon_node:
-        image: sigp/lighthouse:latest
+        image: sigp/lighthouse:${LIGHTHOUSE_VERSION}
         volumes:
             - ./lighthouse-data:/root/.lighthouse
             - ./scripts:/root/scripts
@@ -16,7 +16,7 @@ services:
         command: sh /root/scripts/start-beacon-node.sh
         restart: on-failure
     validator_client:
-        image: sigp/lighthouse:latest
+        image: sigp/lighthouse:${LIGHTHOUSE_VERSION}
         volumes:
             - ./lighthouse-data:/root/.lighthouse
             - ./scripts:/root/scripts
@@ -29,7 +29,7 @@ services:
         command: sh /root/scripts/start-validator-client.sh
         restart: on-failure
     geth:
-        image: ethereum/client-go
+        image: ethereum/client-go:${GETH_VERSION}
         entrypoint: /bin/sh
         volumes:
             - ./geth-data:/root/.ethereum


### PR DESCRIPTION
The current behavior is to pull the docker image tagged as `latest`, which is equivalent to latest master branch. Before mainnet launch I think this behavior should probably be changed so that users pull a proper release instead.

Additionally, any sort of auto-update mechanism is probably a bad idea when it comes to running node, as sometimes a release might require actions from the user, sometimes it might mean joining a contentious fork etc.

This PR contains one way to configure and pin software versions.