### PR TITLE
Added pyrmont in default.env TESTNET comment

### DIFF
--- a/default.env
+++ b/default.env
@@ -4,7 +4,7 @@
 DEBUG_LEVEL=info
 
 # To specify a specific testnet (Lighthouse defaults to the latest running
-# public testnet) set this value. Allowed values are: altona, medalla and spadina
+# public testnet) set this value. Allowed values are: altona, medalla, pyrmont and spadina
 TESTNET=
 
 # Add an arbitary string to the proposing block


### PR DESCRIPTION
Added `pyrmont` in default.env TESTNET comment.