### PR TITLE
Configurable lighthouse and geth data directories

### DIFF
--- a/default.env
+++ b/default.env
@@ -65,6 +65,8 @@ SEARCH_BLOCKS=
 # Set to anything other than empty to enable the metrics endpoint port 5054 on beacon node.
 ENABLE_METRICS=
 
+# Set to anything other than empty to enable automatic validator monitoring.
+ENABLE_MONITORING_AUTO=
 
 # Provide 0x prefixed public keys for manual validator monitoring. To specify multiple
 # public keys add them comma separated.

--- a/default.env
+++ b/default.env
@@ -65,8 +65,6 @@ SEARCH_BLOCKS=
 # Set to anything other than empty to enable the metrics endpoint port 5054 on beacon node.
 ENABLE_METRICS=
 
-# Set to anything other than empty to enable automatic validator monitoring.
-ENABLE_MONITORING_AUTO=
 
 # Provide 0x prefixed public keys for manual validator monitoring. To specify multiple
 # public keys add them comma separated.
@@ -78,3 +76,10 @@ ENABLE_FULL_NETWORK_VIEW=
 
 # Set to anything other than empty to start the lighthouse included slasher.
 START_SLASHER=
+
+# Set to any other directory if you want to change the location of the geth client data.
+GETH_DATA=./geth-data
+
+# Set to any other directory if you want to change the location of the lighthouse client data.
+# Will be set for beacon_node and validator_client.
+LIGHTHOUSE_DATA=./lighthouse-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     beacon_node:
         image: sigp/lighthouse:${LIGHTHOUSE_VERSION}
         volumes:
-            - ./lighthouse-data:/root/.lighthouse
+            - ${LIGHTHOUSE_DATA}:/root/.lighthouse
             - ./scripts:/root/scripts:ro
         ports:
             - 5052:5052/tcp
@@ -18,7 +18,7 @@ services:
     validator_client:
         image: sigp/lighthouse:${LIGHTHOUSE_VERSION}
         volumes:
-            - ./lighthouse-data:/root/.lighthouse
+            - ${LIGHTHOUSE_DATA}:/root/.lighthouse
             - ./scripts:/root/scripts:ro
             - ./validator_keys:/root/validator_keys:ro
         depends_on:
@@ -32,7 +32,7 @@ services:
         image: ethereum/client-go:${GETH_VERSION}
         entrypoint: /bin/sh
         volumes:
-            - ./geth-data:/root/.ethereum
+            - ${GETH_DATA}:/root/.ethereum
             - ./scripts:/root/scripts:ro
         ports:
             - 30303:30303/tcp


### PR DESCRIPTION
I think allowing to configure data directory via dotenv file instead of changing volume mounts manually in docker-compose config would be nice to have. In some cases the location where docker is running does not have enough space for storing lighthouse and geth client data. This would enable someone to easily mount the client data volumes to any other data directory.