### PR TITLE
Changed beacon node flag --eth1-endpoint to --eth1-endpoints

### DIFF
--- a/default.env
+++ b/default.env
@@ -37,9 +37,10 @@ VALIDATOR_COUNT=1
 # is not set to some external geth node.
 START_GETH=
 
-# This is the node that beacon nodes should use whilst they are running and
-# producing blocks. Does not require any accounts.
-VOTING_ETH1_NODE=http://geth:8545
+# These are the nodes that beacon nodes should use whilst they are running and
+# producing blocks. Does not require any accounts. To specify fallback nodes add
+# them comma separated.
+VOTING_ETH1_NODES=http://geth:8545
 
 # Set to anything other than empty to enable the metrics endpoint port 5054 on beacon node.
 ENABLE_METRICS=

--- a/scripts/start-beacon-node.sh
+++ b/scripts/start-beacon-node.sh
@@ -25,7 +25,7 @@ exec lighthouse \
 	--debug-level $DEBUG_LEVEL \
 	--testnet $TESTNET \
 	beacon_node \
-	--eth1-endpoint $VOTING_ETH1_NODE \
+	--eth1-endpoints $VOTING_ETH1_NODES \
 	--http \
 	--http-address 0.0.0.0 \
 	$METRICS_PARAMS \


### PR DESCRIPTION
Added support for fallback nodes as stated in release [v1.0.1](https://github.com/sigp/lighthouse/releases/tag/v1.0.1). Multiple nodes can now be specified in `VOTING_ETH1_NODES` environment variable.