### PR TITLE
Added --eth1-blocks-per-log-query flag to allow to reduce blocks searched for deposit logs

### DIFF
--- a/default.env
+++ b/default.env
@@ -41,5 +41,9 @@ START_GETH=
 # producing blocks. Does not require any accounts.
 VOTING_ETH1_NODE=http://geth:8545
 
+# Set an optional number of blocks searched for deposit logs from eth1 nodes to
+# reduce the size of return result. This may help in case of GetDepositLogsFailed error.
+SEARCH_BLOCKS=
+
 # Set to anything other than empty to enable the metrics endpoint port 5054 on beacon node.
 ENABLE_METRICS=

--- a/scripts/start-beacon-node.sh
+++ b/scripts/start-beacon-node.sh
@@ -21,6 +21,10 @@ if [ "$GRAFFITI" != "" ]; then
 	GRAFFITI_PARAM="--graffiti $GRAFFITI"
 fi
 
+if [ "$SEARCH_BLOCKS" != ""]; then
+  SEARCH_BLOCKS_PARAM="--eth1-blocks-per-log-query $SEARCH_BLOCKS"
+fi
+
 exec lighthouse \
 	--debug-level $DEBUG_LEVEL \
 	--testnet $TESTNET \
@@ -33,4 +37,5 @@ exec lighthouse \
 	--ws-address 0.0.0.0 \
 	--max-skip-slots 700 \
 	$GRAFFITI_PARAM \
-	$ETH1_FLAG
+	$ETH1_FLAG \
+	$SEARCH_BLOCKS_PARAM

--- a/scripts/start-beacon-node.sh
+++ b/scripts/start-beacon-node.sh
@@ -22,7 +22,7 @@ if [ "$GRAFFITI" != "" ]; then
 fi
 
 if [ "$SEARCH_BLOCKS" != ""]; then
-  SEARCH_BLOCKS_PARAM="--eth1-blocks-per-log-query $SEARCH_BLOCKS"
+	SEARCH_BLOCKS_PARAM="--eth1-blocks-per-log-query $SEARCH_BLOCKS"
 fi
 
 exec lighthouse \


### PR DESCRIPTION
Added flag to resolve issues related to `GetDepositLogsFailed` https://github.com/sigp/lighthouse/pull/1931
This is relevant to PR for fallback nodes https://github.com/sigp/lighthouse-docker/pull/45.