### PR TITLE
Prepare for docker image with non-root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The following features are available:
 
 ## Usage
 
-`$ docker-compose up`
+`$ ./start.sh`
 
 A `.lighthouse` directory will be created in the repository root which contains
 the validator keys, beacon node database and other Lighthouse files.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,10 @@ version: "3.0"
 services:
     beacon_node:
         image: sigp/lighthouse:latest
+        user: "${HOST_UID}"
         volumes:
-            - ./lighthouse-data:/root/.lighthouse
-            - ./scripts:/root/scripts
+            - ${LIGHTHOUSE_DATA_DIR}:/home/lighthouse/.lighthouse
+            - ./scripts:/home/lighthouse/scripts
         ports:
             - 5052:5052/tcp
             - 5053:5053/tcp
@@ -13,26 +14,27 @@ services:
             - 9000:9000/tcp
             - 9000:9000/udp
         env_file: .env
-        command: sh /root/scripts/start-beacon-node.sh
+        command: sh /home/lighthouse/scripts/start-beacon-node.sh
         restart: on-failure
     validator_client:
         image: sigp/lighthouse:latest
+        user: "${HOST_UID}"
         volumes:
-            - ./lighthouse-data:/root/.lighthouse
-            - ./scripts:/root/scripts
-            - ./validator_keys:/root/validator_keys
+            - ${LIGHTHOUSE_DATA_DIR}:/home/lighthouse/.lighthouse
+            - ./scripts:/home/lighthouse/scripts
+            - ./validator_keys:/home/lighthouse/validator_keys
         depends_on:
             - beacon_node
         ports:
             - 5064:5064/tcp     # metrics endpoint
         env_file: .env
-        command: sh /root/scripts/start-validator-client.sh
+        command: sh /home/lighthouse/scripts/start-validator-client.sh
         restart: on-failure
     geth:
         image: ethereum/client-go
         entrypoint: /bin/sh
         volumes:
-            - ./geth-data:/root/.ethereum
+            - ${GETH_DATA_DIR}:/root/.ethereum
             - ./scripts:/root/scripts
         ports:
             - 30303:30303/tcp

--- a/scripts/start-validator-client.sh
+++ b/scripts/start-validator-client.sh
@@ -12,7 +12,7 @@ if [ "$ENABLE_METRICS" != "" ]; then
 fi
 
 # Base dir
-DATADIR=/root/.lighthouse/$NETWORK
+DATADIR=/home/lighthouse/.lighthouse/$NETWORK
 
 WALLET_NAME=validators
 WALLET_PASSFILE=$DATADIR/secrets/$WALLET_NAME.pass
@@ -23,7 +23,7 @@ if [ "$START_VALIDATOR" != "" ]; then
 		echo $LAUNCHPAD_KEYSTORE_PASSWD | lighthouse \
 			--network $NETWORK \
 			account validator import \
-			--directory /root/validator_keys \
+			--directory /home/lighthouse/validator_keys \
 			--reuse-password \
 			--stdin-inputs
 	else

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e  # Exit immediately if a command exits with a non-zero status.
+
+export LIGHTHOUSE_DATA_DIR=./lighthouse-data
+export GETH_DATA_DIR=./geth-data
+export HOST_UID=${UID}
+
+# Make sure data dirs are created without root being the owner
+mkdir -p ${LIGHTHOUSE_DATA_DIR}
+mkdir -p ${GETH_DATA_DIR}
+
+#docker-compose pull
+docker-compose down
+docker-compose up -d


### PR DESCRIPTION
Apply changes required assuming https://github.com/sigp/lighthouse/pull/2021 is merged, and lighthouse docker image no longer runs with the root user.

This PR includes changes made by @etimoz in https://github.com/sigp/lighthouse-docker/pull/40.
