### PR TITLE
Add missing space

### DIFF
--- a/scripts/start-beacon-node.sh
+++ b/scripts/start-beacon-node.sh
@@ -24,7 +24,7 @@ if [ "$START_SLASHER" != "" ]; then
 	SLASHER_FLAG="--slasher"
 fi
 
-if [ "$SEARCH_BLOCKS" != ""]; then
+if [ "$SEARCH_BLOCKS" != "" ]; then
 	SEARCH_BLOCKS_PARAM="--eth1-blocks-per-log-query $SEARCH_BLOCKS"
 fi
 


### PR DESCRIPTION
This fixes an error we get on beacon node startup:
```
/root/scripts/start-beacon-node.sh: 27: [: !=: argument expected`
```