### PR TITLE
Enable --private flag via config

### DIFF
--- a/default.env
+++ b/default.env
@@ -10,6 +10,10 @@ NETWORK=
 # Add an arbitrary string to the proposing block
 GRAFFITI=
 
+# Set to anything other than empty to zero-out graffiti and do not publish
+# client information in the identify protocol.
+PRIVATE=
+
 # Set to anything other than empty to start the validator client.
 START_VALIDATOR=
 

--- a/scripts/start-beacon-node.sh
+++ b/scripts/start-beacon-node.sh
@@ -20,6 +20,10 @@ if [ "$GRAFFITI" != "" ]; then
 	GRAFFITI_PARAM="--graffiti $GRAFFITI"
 fi
 
+if [ "$PRIVATE" != "" ]; then
+	PRIVATE_FLAG="--private"
+fi
+
 if [ "$START_SLASHER" != "" ]; then
 	SLASHER_FLAG="--slasher"
 fi
@@ -43,4 +47,5 @@ exec lighthouse \
 	$GRAFFITI_PARAM \
 	$ETH1_FLAG \
 	$SLASHER_FLAG \
-	$SEARCH_BLOCKS_PARAM
+	$SEARCH_BLOCKS_PARAM \
+	$PRIVATE_FLAG


### PR DESCRIPTION
Added `PRIVATE` configuration variable to enable `--private` flag as stated in release [v1.0.3](https://github.com/sigp/lighthouse/releases/tag/v1.0.3).