### PR TITLE
delete ws flags and max skip slots

### DIFF
--- a/scripts/start-beacon-node.sh
+++ b/scripts/start-beacon-node.sh
@@ -37,9 +37,6 @@ exec lighthouse \
 	--http \
 	--http-address 0.0.0.0 \
 	$METRICS_PARAMS \
-	--ws \
-	--ws-address 0.0.0.0 \
-	--max-skip-slots 700 \
 	$GRAFFITI_PARAM \
 	$ETH1_FLAG \
 	$SLASHER_FLAG \


### PR DESCRIPTION
The WebSockets flags have been removed in the latest `unstable`, so we should delete them before the next release