### PR TITLE
use stable geth

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
         command: sh /root/scripts/start-validator-client.sh
         restart: on-failure
     geth:
-        image: ethereum/client-go:v1.9.25
+        image: ethereum/client-go:stable
         entrypoint: /bin/sh
         volumes:
             - ./geth-data:/root/.ethereum

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
         command: sh /root/scripts/start-validator-client.sh
         restart: on-failure
     geth:
-        image: ethereum/client-go
+        image: ethereum/client-go:v1.9.25
         entrypoint: /bin/sh
         volumes:
             - ./geth-data:/root/.ethereum


### PR DESCRIPTION
`ethereum/client-go:latest` uses geth's `master` branch which is unstable. For some reason geth's `net_version` endpoint wasn't working here:

```
geth_1              | WARN [12-17|16:14:35.908] Served net_version                       conn=172.21.0.2:37022 reqid=1 t="27.489µs" err="the method net_version does not exist/is not available"
```

geth also has a `stable` tag, which works for me
