### PR TITLE
Use --beacon-nodes not --beacon-node

### DIFF
--- a/scripts/start-validator-client.sh
+++ b/scripts/start-validator-client.sh
@@ -60,5 +60,5 @@ if [ "$START_VALIDATOR" != "" ]; then
 		--network $NETWORK \
 		validator \
 		$METRICS_PARAMS \
-		--beacon-node http://beacon_node:5052
+		--beacon-nodes http://beacon_node:5052
 fi


### PR DESCRIPTION
It seems the `--beacon-node` flag might have been broken in v1.0.5 (https://github.com/sigp/lighthouse/issues/2118). The logs I get from the validator client include
```
WARN Offline beacon node
WARN Unable to connect to a beacon node
```

The new `--beacon-nodes` flag works, so this PR uses that.