### PR TITLE
Remove the deprecated geth --nousb flag

### DIFF
--- a/scripts/start-geth.sh
+++ b/scripts/start-geth.sh
@@ -11,8 +11,8 @@ fi
 
 if [ "$START_GETH" != "" ]; then
 	if [ "$NETWORK" != "$DEFAULT_NETWORK" ]; then
-		exec geth --goerli --http --http.addr "0.0.0.0" --http.vhosts=* --http.api "eth,net" --ipcdisable --nousb
+		exec geth --goerli --http --http.addr "0.0.0.0" --http.vhosts=* --http.api "eth,net" --ipcdisable
 	else
-		exec geth --http --http.addr "0.0.0.0" --http.vhosts=* --http.api "eth,net" --ipcdisable --nousb
+		exec geth --http --http.addr "0.0.0.0" --http.vhosts=* --http.api "eth,net" --ipcdisable
 	fi
 fi


### PR DESCRIPTION
`--nousb` is the default in v1.10.x and the flag is deprecated