### PR TITLE
Allow specifying redundant beacon nodes

### DIFF
--- a/default.env
+++ b/default.env
@@ -50,6 +50,10 @@ START_GETH=
 # them comma separated.
 VOTING_ETH1_NODES=http://geth:8545
 
+# These are the beacon nodes the validator client will attempt to contact to
+# perform duties. To specify fallback nodes add them comma separated.
+VOTING_ETH2_NODES=http://beacon_node:5052
+
 # Set an optional number of blocks searched for deposit logs from eth1 nodes to
 # reduce the size of return result. This may help in case of GetDepositLogsFailed error.
 SEARCH_BLOCKS=

--- a/scripts/start-validator-client.sh
+++ b/scripts/start-validator-client.sh
@@ -60,5 +60,5 @@ if [ "$START_VALIDATOR" != "" ]; then
 		--network $NETWORK \
 		validator \
 		$METRICS_PARAMS \
-		--beacon-node http://beacon_node:5052
+		--beacon-nodes $VOTING_ETH2_NODES
 fi


### PR DESCRIPTION
Added `VOTING_ETH2_NODES` environment variable to specify redundant beacon nodes which is possible since `--beacon-nodes` in [v1.0.5](https://github.com/sigp/lighthouse/releases/tag/v1.0.5).
