### PR TITLE
Node monitoring

### DIFF
--- a/default.env
+++ b/default.env
@@ -76,5 +76,8 @@ ENABLE_MONITORING_MANUAL=
 # validators that aren't connected to the beacon node.
 ENABLE_FULL_NETWORK_VIEW=
 
+# Set a monitoring endpoint to provide client information to.
+MONITORING_ENDPOINT=
+
 # Set to anything other than empty to start the lighthouse included slasher.
 START_SLASHER=

--- a/scripts/start-beacon-node.sh
+++ b/scripts/start-beacon-node.sh
@@ -44,6 +44,10 @@ if [ "$ENABLE_FULL_NETWORK_VIEW" != "" ]; then
 	ENABLE_FULL_NETWORK_VIEW_PARAMS="--subscribe-all-subnets --import-all-attestations"
 fi
 
+if [ "$MONITORING_ENDPOINT" != "" ]; then
+	MONITORING_ENDPOINT_PARAM="--monitoring-endpoint $MONITORING_ENDPOINT"
+fi
+
 exec lighthouse \
 	--debug-level $DEBUG_LEVEL \
 	--network $NETWORK \
@@ -59,4 +63,5 @@ exec lighthouse \
 	$PRIVATE_FLAG \
 	$ENABLE_MONITORING_AUTO_FLAG \
 	$ENABLE_MONITORING_MANUAL_PARAMS \
-	$ENABLE_FULL_NETWORK_VIEW_PARAMS
+	$ENABLE_FULL_NETWORK_VIEW_PARAMS \
+	$MONITORING_ENDPOINT_PARAM


### PR DESCRIPTION
Adds the option to set the node monitoring endpoint param (`--monitoring-endpoint`) as described in the beaconcha.in [knowledgebase](https://kb.beaconcha.in/beaconcha.in-explorer/mobile-app-less-than-greater-than-beacon-node).