### PR TITLE
Add --enable-doppelganger-protection argument

### DIFF
--- a/default.env
+++ b/default.env
@@ -76,5 +76,8 @@ ENABLE_MONITORING_MANUAL=
 # validators that aren't connected to the beacon node.
 ENABLE_FULL_NETWORK_VIEW=
 
+# Set to anything other than empty to enable doppelganger protection.
+ENABLE_DOPPELGANGER_PROTECTION=
+
 # Set to anything other than empty to start the lighthouse included slasher.
 START_SLASHER=

--- a/scripts/start-validator-client.sh
+++ b/scripts/start-validator-client.sh
@@ -11,6 +11,10 @@ if [ "$ENABLE_METRICS" != "" ]; then
   METRICS_PARAMS="--metrics --metrics-address 0.0.0.0 "
 fi
 
+if [ "$ENABLE_DOPPELGANGER_PROTECTION" != "" ]; then
+  DOPPELGANGER_PROTECTION="--enable-doppelganger-protection "
+fi
+
 # Base dir
 DATADIR=/root/.lighthouse/$NETWORK
 
@@ -60,5 +64,6 @@ if [ "$START_VALIDATOR" != "" ]; then
 		--network $NETWORK \
 		validator \
 		$METRICS_PARAMS \
-		--beacon-nodes $VOTING_ETH2_NODES
+		--beacon-nodes $VOTING_ETH2_NODES \
+		$DOPPELGANGER_PROTECTION
 fi


### PR DESCRIPTION
Adds option to enable doppelganger protection introduced in [v1.0.5](https://github.com/sigp/lighthouse/releases/tag/v1.5.0).