### PR TITLE
Added--checkpoint-sync-url param for beacon node

### DIFF
--- a/default.env
+++ b/default.env
@@ -83,5 +83,8 @@ ENABLE_FULL_NETWORK_VIEW=
 # Set to anything other than empty to enable doppelganger protection.
 ENABLE_DOPPELGANGER_PROTECTION=
 
+# Set to another synced beacon node's URL to enable checkpoint sync.
+CHECKPOINT_SYNC_URL=
+
 # Set to anything other than empty to start the lighthouse included slasher.
 START_SLASHER=

--- a/scripts/start-beacon-node.sh
+++ b/scripts/start-beacon-node.sh
@@ -48,6 +48,10 @@ if [ "$ENABLE_FULL_NETWORK_VIEW" != "" ]; then
 	ENABLE_FULL_NETWORK_VIEW_PARAMS="--subscribe-all-subnets --import-all-attestations"
 fi
 
+if [ "$CHECKPOINT_SYNC_URL" != "" ]; then
+	CHECKPOINT_SYNC_URL_PARAM="--checkpoint-sync-url $CHECKPOINT_SYNC_URL"
+fi
+
 exec lighthouse \
 	--debug-level $DEBUG_LEVEL \
 	--network $NETWORK \
@@ -64,4 +68,5 @@ exec lighthouse \
 	$ENABLE_MONITORING_AUTO_FLAG \
 	$ENABLE_MONITORING_MANUAL_PARAMS \
 	$ENABLE_FULL_NETWORK_VIEW_PARAMS \
-	$MONITORING_SERVICE_PARAMS
+	$MONITORING_SERVICE_PARAMS \
+	$CHECKPOINT_SYNC_URL_PARAM


### PR DESCRIPTION
- Added automatic checkout sync and `CHECKPOINT_SYNC_URL` variable in `default.env`.